### PR TITLE
dylib to dll

### DIFF
--- a/ffi/hello_world/pubspec.yaml
+++ b/ffi/hello_world/pubspec.yaml
@@ -4,6 +4,8 @@ description: >-
   A super simple example of calling C code from Dart with FFI
 author: Matt Sullivan <mattsullivan@google.com>
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: ">=2.5.0 <3.0.0"
 dev_dependencies:
   test: ^1.5.3
+dependency_overrides:
+  analyzer: 0.39.1

--- a/ffi/primitives/c/Makefile
+++ b/ffi/primitives/c/Makefile
@@ -11,4 +11,4 @@ dll: primitives.o
 	gcc -shared primitives.o -o ../primitives.dll
 
 clean:
-	rm a.out primitives.o ../primitives.dll
+	rm -f a.out primitives.o ../primitives.dll ../primitives.dylib

--- a/ffi/primitives/c/Makefile
+++ b/ffi/primitives/c/Makefile
@@ -11,4 +11,4 @@ dll: primitives.o
 	gcc -shared primitives.o -o ../primitives.dll
 
 clean:
-	rm a.out primitives.o ../primitives.dylib
+	rm a.out primitives.o ../primitives.dll

--- a/ffi/primitives/c/Makefile
+++ b/ffi/primitives/c/Makefile
@@ -8,7 +8,7 @@ dylib: primitives.o
 	gcc -dynamiclib -undefined suppress -flat_namespace primitives.o -o ../primitives.dylib
 
 dll: primitives.o
-	gcc -shared primitives.o -o ../primitives.dylib
+	gcc -shared primitives.o -o ../primitives.dll
 
 clean:
 	rm a.out primitives.o ../primitives.dylib

--- a/ffi/primitives/pubspec.yaml
+++ b/ffi/primitives/pubspec.yaml
@@ -9,6 +9,5 @@ dependencies:
   ffi: ^0.1.3-dev.3
 dev_dependencies:
   test: ^1.5.3
-
 dependency_overrides:
   analyzer: 0.39.1

--- a/ffi/primitives/pubspec.yaml
+++ b/ffi/primitives/pubspec.yaml
@@ -4,8 +4,11 @@ description: >-
   A super simple example of calling C code from Dart with FFI
 author: Matt Sullivan <mattsullivan@google.com>
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: ">=2.5.0 <3.0.0"
 dependencies:
   ffi: ^0.1.3-dev.3
 dev_dependencies:
   test: ^1.5.3
+
+dependency_overrides:
+  analyzer: 0.39.1

--- a/ffi/structs/c/Makefile
+++ b/ffi/structs/c/Makefile
@@ -11,4 +11,4 @@ dll: structs.o
 	gcc -shared structs.o -o ../structs.dll
 
 clean:
-	rm a.out structs.o ../structs.dll
+	rm -f a.out structs.o ../structs.dll ../structs.dylib


### PR DESCRIPTION
The file extension should be `.dll` on windows for consistency.
When using `make dll`

https://github.com/dart-lang/samples/blob/master/ffi/primitives/primitives.dart#L39