### PR TITLE
Fixing 'Failing to load dynamic library' on Windows

### DIFF
--- a/ffi/hello_world/hello.dart
+++ b/ffi/hello_world/hello.dart
@@ -13,8 +13,8 @@ typedef HelloWorld = void Function();
 main() {
   // Open the dynamic library
   var path = "./hello_library/libhello.so";
-  if (Platform.isMacOS) path = "./hello_library/libhello.dylib";
-  if (Platform.isWindows) path = "hello_library\libhello.dll";
+  if (Platform.isMacOS) path = './hello_library/libhello.dylib';
+  if (Platform.isWindows) path = r'hello_library\Debug\hello.dll';
   final dylib = ffi.DynamicLibrary.open(path);
   // Look up the C function 'hello_world'
   final HelloWorld hello = dylib

--- a/ffi/hello_world/hello_library/CMakeLists.txt
+++ b/ffi/hello_world/hello_library/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 project(hello_library VERSION 1.0.0 LANGUAGES C)
-add_library(hello_library SHARED hello.c)
+add_library(hello_library SHARED hello.c hello.def)
 add_executable(hello_test hello.c)
 
 set_target_properties(hello_library PROPERTIES


### PR DESCRIPTION
Initial attempt at fixing https://github.com/dart-lang/samples/issues/32

However, I am still hitting the following issue, which I assume is visibility related:

```bash
PS C:\src\dart-samples\ffi\hello_world> dart .\hello.dart
Unhandled exception:
Invalid argument(s): Failed to lookup symbol (127)
#0      DynamicLibrary.lookup (dart:ffi-patch/ffi_dynamic_library_patch.dart:33:29)
#1      main (file:///C:/src/dart-samples/ffi/hello_world/hello.dart:21:8)
#2      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:307:19)
#3      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:174:12)
```