### PR TITLE
Fix native library name for Linux and macOS

### DIFF
--- a/ffi/structs/structs.dart
+++ b/ffi/structs/structs.dart
@@ -54,8 +54,8 @@ typedef CreatePlace = Pointer<Place> Function(
     Pointer<Utf8> name, double latitude, double longitude);
 
 main() {
-  var path = './structs_library/structs.so';
-  if (Platform.isMacOS) path = './structs_library/structs.dylib';
+  var path = './structs_library/libstructs.so';
+  if (Platform.isMacOS) path = './structs_library/libstructs.dylib';
   if (Platform.isWindows) path = r'structs_library\Debug\structs.dll';
   final dylib = DynamicLibrary.open(path);
 

--- a/ffi/structs/test/structs_test.dart
+++ b/ffi/structs/test/structs_test.dart
@@ -18,7 +18,7 @@ void main() async {
       expect(make.exitCode, 0);
 
       // Verify dynamic library was created
-      var file = File('./structs_library/structs.so');
+      var file = File('./structs_library/libstructs.so');
       expect(await file.exists(), true);
 
       // Run the Dart script


### PR DESCRIPTION
Building on Linux names the file "libstructs.so". I haven't tested on macOS, but judging from the other ffi samples it seems it should also be renamed with the "lib" prefix.