### PR TITLE
Mention SDK 2.9.0-14.0.dev instead of 2.9.0-13

### DIFF
--- a/null_safety/calculate_lix/README.md
+++ b/null_safety/calculate_lix/README.md
@@ -4,19 +4,19 @@ This is a small code example of an app that calculates the 'lix' readability
 index for a text file. The implementation uses the new Dart null safety feature,
 and is meant to demonstrate how this feature works in a practical example,
 as well as serve as a demonstration of how to configure and run code with null
-safety at it's current tech preview stage.
+safety at its current tech preview stage.
 
 ## Running the example code
 
 The code works only with the first tech preview of null safety, Dart SDK version
-`2.9.0-13.0.dev`. You will need to download a copy of this Dart SDK even if you
+`2.9.0-14.0.dev`. You will need to download a copy of this Dart SDK even if you
 have a Flutter or Dart SDK installed already, and you'll want to use this
 preview SDK only for experimenting with null safety. Specifically, do not use it
 for any kind of production coding.
 
 ### Dart preview SDK installation
 
-  1. Download the tech preview 1 build is version **`2.9.0-13.0.dev`** from the
+  1. Download the tech preview 1 build is version **`2.9.0-14.0.dev`** from the
      dev-channel in the SDK archive:
      https://dart.dev/tools/sdk/archive#dev-channel
    
@@ -53,7 +53,7 @@ VSCode:
 
   1. Tell VSCode to use the preview Dart SDK: Open `bin/main.dart` and then
      locate the 'Dart: <version number>' selector in the status bar at the
-     bottom, and select `Dart: 2.9.0-13.0.dev`.
+     bottom, and select `Dart: 2.9.0-14.0.dev`.
 
   1. Press F5 and the project should run and print a message in the Debug
      Console.
@@ -71,7 +71,7 @@ VSCode:
 
   1. Select both 'Enable Dart support' checkmarks at the top and bottom of the dialog.
   
-  1. Under Dart SDK specify the path to the Dart preview SDK (2.9.0-13.0.dev). Click OK.
+  1. Under Dart SDK specify the path to the Dart preview SDK (2.9.0-14.0.dev). Click OK.
 
   1. Select Run > Run and the project should run and print a message in the Run
      pane.


### PR DESCRIPTION
(Optional.)

As of today, 14 is out and it's what you get if you go to SDK downloads. It seems like a weird requirement to go one version number back.

I'm testing with 14 and everything works okay.