### PR TITLE
Add more places to try and learn NNBD, and an example for per-file NNBD

### DIFF
--- a/null_safety/calculate_lix/.vscode/launch.json
+++ b/null_safety/calculate_lix/.vscode/launch.json
@@ -5,8 +5,20 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Dart",
+            "name": "Dart 2.9",
             "program": "bin/main.dart",
+            "request": "launch",
+            "type": "dart",
+            "vmAdditionalArgs": [
+                "--enable-experiment=non-nullable",
+            ],
+            "args": [
+                "text/lorem-ipsum.txt"
+            ]
+        },
+        {
+            "name": "Dart 2.9 backward compatible",
+            "program": "bin/main-legacy.dart",
             "request": "launch",
             "type": "dart",
             "vmAdditionalArgs": [

--- a/null_safety/calculate_lix/README.md
+++ b/null_safety/calculate_lix/README.md
@@ -82,15 +82,9 @@ VSCode:
 
 Once you have the code running, here some suggestions for things to try:
 
-  * In `lib/lix.dart` line 30, try to remove the `required` keyword from one or
-    more fields in the constructor, and notice the error shown.
+  * Look for several `@TRYTHIS` comment and follow the instruction. Most of the trythis will
+  result in immediate static analysis and/or compile error. A few will result in runtime exception,
+  most probably `LateInitializationError`
 
-  * In `lib/lix.dart` line 49, try to delete the code that initializes one or more
-    fields (e.g. `words: words`) and notice the error shown.
-
-  * In `lib/lix.dart` line 9, try to make `words` a nullable variable (`int?
-    words`), and notice how we don't get errors about not checking for null in
-    the `_calculate()` method.
-
-  * In `lib/lix.dart` line 22, try to remove the `late` keyword from
-    `readability`, and notice how we get an error in the constructor.
+  * Instead of running `bin/main.dart`, run `main-legacy.dart`, or in VS Code, run `Dart 2.9 backward compatible`,
+  and then remove `// @dart = 2.8` in `main-legacy.dart` and run again, to see how NNBD can be disabled per file.

--- a/null_safety/calculate_lix/bin/main-legacy.dart
+++ b/null_safety/calculate_lix/bin/main-legacy.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @TRYTHIS: remove the following line
-// @dart = 2.9
+// @dart = 2.8
 
 import 'dart:io';
 
@@ -22,26 +22,21 @@ void main(List<String> arguments) {
     // elements. As a result, the Dart analyzer knows that `fileName` isn't
     // null.
     final fileName = arguments[0];
-    print('Calculating Lix of "$fileName" with NNBD');
+    print('Calculating Lix of "$fileName" withOUT NNBD');
 
     // Calculate lix.
-    // a smart way to have a "final" in the right scope
-    // @TRYTHIS: convert to `final Lix l`
-    // @TRYTHIS: convert to `final Lix? l`
-    // @TRYTHIS: convert to `Lix? l`
-    late final Lix l;
+    Lix l;
     try {
       l = Lix.fromString(File(fileName).readAsStringSync());
     } catch (ArgumentError) {
       print('Invalid input, could not calculate lix!\n'
           'The input text must contain at least one full sentence.');
     }
-    late final String description;
+    String description;
     switch (l.describe()) {
       case 'unknown':
         print('Lix analysis failed');
-        // @TRYTHIS: replace with "break", and for the value to be 'unknown'
-        return;
+        return; // try replace with "break", and for the value to be 'unknown'
       default:
         description = l.describe();
     }

--- a/null_safety/calculate_lix/lib/lix.dart
+++ b/null_safety/calculate_lix/lib/lix.dart
@@ -6,6 +6,7 @@
 /// https://readabilityformulas.com/the-LIX-readability-formula.php.
 class Lix {
   /// Number of words in general.
+  // @TRYTHIS: convert to `int? words`
   int words;
 
   /// Number of words with more than 6 characters.
@@ -19,6 +20,8 @@ class Lix {
   /// TIP: `readability` isn't passed to the constructor, but calculated. By
   /// adding the late keyword we tell the analyzer that it will be initialized
   /// later in the program.
+  // @TRYTHIS: convert to `int readability`
+  // @TRYTHIS: convert to `int? readability`
   late int readability;
 
   /// TIP: Because the fields are all non-nullable, the constructor must
@@ -27,11 +30,13 @@ class Lix {
   /// constructor. 'required' is a new keyword introduced as part of null safety
   /// which replaces the previous '@required' annotation.
   Lix({
+    // @TRYTHIS: convert to `@required this.words`
     required this.words,
     required this.longWords,
     required this.periods,
   }) {
-    readability = this._calculate();
+    // @TRYTHIS: remove the following line
+    // readability = this._calculate();
   }
 
   factory Lix.fromString(String text) {
@@ -46,7 +51,12 @@ class Lix {
     var words = allWords.length;
     var longWords = allWords.where((w) => w.length > 6).toList().length;
 
-    return Lix(words: words, longWords: longWords, periods: periods);
+    return Lix(
+      // @TRYTHIS: remove the following line
+      words: words,
+      longWords: longWords,
+      periods: periods,
+    );
   }
 
   /// TIP: Notice how we declare a non-nullable uninitialized `result` variable,
@@ -59,11 +69,16 @@ class Lix {
   int _calculate() {
     int result;
 
-    if (words == 0 || periods == 0) {
+    if (words == 0) {
+      // @TRYTHIS: remove the following line
+      throw (ArgumentError('Text must contain at least one full sentence.'));
+    } else if (periods == 0) {
+      // @TRYTHIS: remove the following line
       throw (ArgumentError('Text must contain at least one full sentence.'));
     } else {
       final sentenceLength = words / periods;
       final wordLength = (longWords * 100) / words;
+      // @TRYTHIS: remove the following line
       result = (sentenceLength + wordLength).round();
     }
 
@@ -74,7 +89,10 @@ class Lix {
   /// `readability` and so it's ok to have a non-nullable return type (try
   /// removing the last else-statement).
   String describe() {
-    if (readability > 0 && readability < 20) {
+    late final int localReadability;
+    // @TRYTHIS: remove the following line
+    localReadability = this.readability;
+    if (localReadability > 0 && readability < 20) {
       return 'very easy';
     } else if (readability < 30) {
       return 'easy';
@@ -85,6 +103,7 @@ class Lix {
     } else if (readability < 60) {
       return 'very hard';
     } else {
+      // @TRYTHIS: remove the following line
       return 'unknown';
     }
   }


### PR DESCRIPTION
There is one place I expect static analysis to pick it up, but instead it's a runtime error. It's in the switch case in https://github.com/dart-lang/samples/pull/69/commits/4859de40719de60f32c4153095ebdfc5e677b22c#diff-9e0b069eeab563d6a82928ebc03a01c5R39 , compiled with `Dart VM version: 2.9.0-14.1.beta (beta) (Tue Jun 9 10:52:57 2020 +0200) on "macos_x64"`