### PR TITLE
Bump version for lix sample

### DIFF
--- a/null_safety/calculate_lix/README.md
+++ b/null_safety/calculate_lix/README.md
@@ -1,4 +1,4 @@
-# Null safety example: A CLI-app for calculating lix
+# Null safety example: A CLI app for calculating lix
 
 This is a small code example of an app that calculates the 'lix' readability
 index for a text file. The implementation uses the new Dart null safety feature,
@@ -8,23 +8,18 @@ safety at its current tech preview stage.
 
 ## Running the example code
 
-The code works only with tech preview builds of null safety from the Dart dev
-channel. You will need to download a copy of this Dart SDK even if you have a
-Flutter or Dart SDK installed already, and you'll want to use this preview SDK
-only for experimenting with null safety. Specifically, do not use it for any
-kind of production coding.
+The code works only with tech preview builds of null safety from the `dev`
+channel. If you're using Flutter, you can run:
 
-### Dart preview SDK installation
+```cmd
+flutter channel dev
+```
 
-  1. Download the latest null safety preview build from the dev-channel in the
-     SDK archive: https://dart.dev/tools/sdk/archive#dev-channel. The
-     instructions below use `2.10.0-56.0.dev`; you get download a more recent
-     build.
-   
-  1. Unzip the SDK to a folder, e.g. `/Users/michael/dev/preview/dart-sdk` or
-     `C:\Users\michael\dev\preview\dart-sdk\`
+to switch to this channel; alternatively, you may download and install the
+latest null safety preview build of Dart from the [Dart SDK
+archive](https://dart.dev/tools/sdk/archive#dev-channel).
 
-### Running from the terminal/command-prompt
+### Running from the terminal / command prompt
 
 Because null safety is still in tech preview, we need to pass a so-called
 'experiment flag' when invoking and Dart command in the terminal, which looks
@@ -32,14 +27,15 @@ like this: `--enable-experiment=non-nullable`.
 
 To run the main app, type these commands in the terminal/command-prompt:
 
-  - Windows:
-    - `cd <folder with samples repo>\null_safety\calculate_lix\`
-    - `C:\Users\michael\dev\preview\dart-sdk\bin\dart pub get`
-    - `C:\Users\michael\dev\preview\dart-sdk\bin\dart --enable-experiment=non-nullable run bin\main.dart text\lorem-ipsum.txt`
-  - macOS/Linux:
-    - `cd <folder with samples repo>/null_safety/calculate_lix/`
-    - `/Users/michael/dev/preview/dart-sdk/bin/dart pub get`
-    - `/Users/michael/dev/preview/dart-sdk/bin/dart --enable-experiment=non-nullable run bin/main.dart text/lorem-ipsum.txt`
+```cmd
+$ cd <folder with samples repo>/null_safety/calculate_lix/
+$ dart pub get
+$ dart --enable-experiment=non-nullable run bin/main.dart text/lorem-ipsum.txt
+```
+
+*Note*: You may see a warning "Overriding the upper bound Dart SDK constraint"
++when running pub get. You can ignore this, which is a temporary issue only
++expected during the preview.
 
 ### Running from VSCode
 
@@ -47,16 +43,19 @@ This example contains a launch configuration for VSCode that runs
 `bin/main.dart` passing both the experimental flag, so to run the sample in
 VSCode:
 
-  1. Edit your VSCode configuration to point to one additional Dart SDK, the
-     preview SDK we just downloaded. See [details
+  1. If you're using a separate copy of Dart, rather than the Flutter `dev`
+     channel, edit your VSCode configuration to point to one additional Dart
+     SDK, the preview SDK we just downloaded. See [details
      here](https://dartcode.org/docs/quickly-switching-between-sdk-versions/)
-     for what values to put in **View > Command Palette > Open Settings (JSON)**.
+     for what values to put in **View > Command Palette > Open Settings
+     (JSON)**.
 
   1. Invoke **File > Open**, and select the `calculate_lix` folder.
 
   1. Tell VSCode to use the preview Dart SDK: Open `bin/main.dart` and then
-     locate the 'Dart: <version number>' selector in the status bar at the
-     bottom, and select `Dart: 2.10.0-56.0.dev`.
+     locate the 'Dart: \<version number\>' selector in the status bar at the
+     bottom, and select `Dart: 2.11.0-xxx.0.dev` (where `xxx` is the latest
+     version available.)
 
   1. Select **Run > Run** and the project should run and print a message in the Debug
      Console.
@@ -74,7 +73,9 @@ VSCode:
 
   1. Select both 'Enable Dart support' checkmarks at the top and bottom of the dialog.
   
-  1. Under Dart SDK specify the path to the Dart preview SDK (2.9.0-14.0.dev). Click OK.
+  1. Under Dart SDK specify the path to the Dart preview SDK
+     (`2.11.0-xxx.0.dev`, where `xxx` is the latest version available). Click
+     OK.
 
   1. Select Run > Run and the project should run and print a message in the Run
      pane.
@@ -83,15 +84,15 @@ VSCode:
 
 Once you have the code running, here some suggestions for things to try:
 
-  * In `lib/lix.dart` line 30, try to remove the `required` keyword from one or
-    more fields in the constructor, and notice the error shown.
+* In `lib/lix.dart` line 30, try to remove the `required` keyword from one or
+  more fields in the constructor, and notice the error shown.
 
-  * In `lib/lix.dart` line 49, try to delete the code that initializes one or more
-    fields (e.g. `words: words`) and notice the error shown.
+* In `lib/lix.dart` line 49, try to delete the code that initializes one or more
+  fields (e.g. `words: words`) and notice the error shown.
 
-  * In `lib/lix.dart` line 9, try to make `words` a nullable variable (`int?
-    words`), and notice how we don't get errors about not checking for null in
-    the `_calculate()` method.
+* In `lib/lix.dart` line 9, try to make `words` a nullable variable (`int?
+  words`), and notice how we don't get errors about not checking for null in
+  the `_calculate()` method.
 
-  * In `lib/lix.dart` line 22, try to remove the `late` keyword from
-    `readability`, and notice how we get an error in the constructor.
+* In `lib/lix.dart` line 22, try to remove the `late` keyword from
+  `readability`, and notice how we get an error in the constructor.

--- a/null_safety/calculate_lix/pubspec.lock
+++ b/null_safety/calculate_lix/pubspec.lock
@@ -7,6 +7,6 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-56.0.dev <2.10.0"
+  dart: ">=2.10.0-78 <=2.11.0-207.0.dev"

--- a/null_safety/calculate_lix/pubspec.lock
+++ b/null_safety/calculate_lix/pubspec.lock
@@ -9,4 +9,4 @@ packages:
     source: hosted
     version: "1.15.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-78 <=2.11.0-207.0.dev"
+  dart: ">=2.10.0-78 <=2.11.0-242.0.dev"

--- a/null_safety/calculate_lix/pubspec.yaml
+++ b/null_safety/calculate_lix/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   sdk: '>=2.10.0-56.0.dev <3.0.0'
 
 dependencies:
-  collection: '>=1.15.0-nullsafety.3'
+  collection: ^1.15.0-nullsafety.3

--- a/null_safety/calculate_lix/pubspec.yaml
+++ b/null_safety/calculate_lix/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command-line application demonstrating use of null safety.
 version: 1.1.1
 
 environment:
-  sdk: '>=2.10.0-56.0.dev <3.0.0'
+  sdk: '>=2.10.0-56.0.dev <2.12.0'
 
 dependencies:
   collection: ^1.15.0-nullsafety.3

--- a/null_safety/calculate_lix/pubspec.yaml
+++ b/null_safety/calculate_lix/pubspec.yaml
@@ -1,9 +1,9 @@
 name: calculate_lix
 description: A command-line application demonstrating use of null safety.
-version: 1.1.0
+version: 1.1.1
 
 environment:
-  sdk: '>=2.10.0-56.0.dev <2.11.0'
+  sdk: '>=2.10.0-56.0.dev <3.0.0'
 
 dependencies:
-  collection: 1.15.0-nullsafety.2
+  collection: '>=1.15.0-nullsafety.3'


### PR DESCRIPTION
Current version is incompatible with what's on the Flutter `master` channel. 