### PR TITLE
Create dart.yml

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,44 @@
+name: Dart
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Every day at midnight
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [dev,beta,stable]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: ${{ matrix.sdk }}
+
+      - name: Print Dart SDK version
+        run: dart --version
+
+      - name: "PKGS: command_line, extension_methods, ffi/hello_world, ffi/primitives, ffi/structs, ffi/system-command, native_app; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
+        env: 
+          PKGS: "command_line extension_methods ffi/hello_world ffi/primitives ffi/structs ffi/system-command native_app"
+        run: ./tool/travis.sh dartanalyzer
+
+      - name: "PKGS: command_line, extension_methods, ffi/hello_world, ffi/primitives, ffi/structs, ffi/system-command, native_app; TASKS: `dartfmt -n --set-exit-if-changed .`"
+        env: 
+          PKGS: "command_line extension_methods ffi/hello_world ffi/primitives ffi/structs ffi/system-command native_app"
+        run: ./tool/travis.sh dartfmt
+      
+      - name: "PKG: command_line, extension_methods, ffi/hello_world, ffi/primitives; TASKS: `pub run test`"
+        env: 
+          PKGS: "command_line extension_methods ffi/hello_world ffi/primitives"
+        run: ./tool/travis.sh test


### PR DESCRIPTION
Hey @redbrogdon and @johnpryan,

I started porting the travis test set to Github Actions and I hit something of a head scratcher. I realised that our Travis tests purport to run tests on windows... using a shell script runner. Which makes almost no sense. Unless the Travis windows machines have cygwin or similar installed.

For sample run through, please see https://github.com/domesticmouse/samples-1/pull/1

Note, the windows tests appear to pass, even though some of the tests are specifically written for linux only (and test for the presence of a generated .so file ... as opposed to the .dll or .dylib that should be created on Windows and macOS respectively. 