### PR TITLE
[ffi] Fix memory leaks

### DIFF
--- a/ffi/.gitignore
+++ b/ffi/.gitignore
@@ -6,6 +6,12 @@ a.out
 sdk-version
 *snapshot*
 pubspec.lock
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+Makefile
+primitives/primitives_library/primitives_test
+structs/structs_library/structs_test
 
 # Windows
 *.obj

--- a/ffi/primitives/primitives.dart
+++ b/ffi/primitives/primitives.dart
@@ -35,6 +35,12 @@ typedef multi_sum_func = Int32 Function(
     Int32 numCount, Int32 a, Int32 b, Int32 c);
 typedef MultiSum = int Function(int numCount, int a, int b, int c);
 
+// C free function - void free_pointer(int *int_pointer);
+//
+// Example of how to free pointers that were allocated in C.
+typedef free_pointer_func = Void Function(Pointer<Int32> a);
+typedef FreePointer = void Function(Pointer<Int32> a);
+
 main() {
   // Open the dynamic library
   var libraryPath = path.join(
@@ -64,6 +70,9 @@ main() {
   final subtract = subtractPointer.asFunction<Subtract>();
   print('3 - 5 = ${subtract(p, 5)}');
 
+  // Free up allocated memory.
+  calloc.free(p);
+
   // calls int *multiply(int a, int b);
   final multiplyPointer =
       dylib.lookup<NativeFunction<multiply_func>>('multiply');
@@ -73,13 +82,16 @@ main() {
   final int result = resultPointer.value;
   print('3 * 5 = $result');
 
+  // Free up allocated memory. This time in C, because it was allocated in C.
+  final freePointerPointer =
+      dylib.lookup<NativeFunction<free_pointer_func>>('free_pointer');
+  final freePointer = freePointerPointer.asFunction<FreePointer>();
+  freePointer(resultPointer);
+
   // example calling a C function with varargs
   // calls int multi_sum(int nr_count, ...);
   final multiSumPointer =
       dylib.lookup<NativeFunction<multi_sum_func>>('multi_sum');
   final multiSum = multiSumPointer.asFunction<MultiSum>();
   print('3 + 7 + 11 = ${multiSum(3, 3, 7, 11)}');
-
-  // Free up allocated memory.
-  calloc.free(p);
 }

--- a/ffi/primitives/primitives_library/primitives.c
+++ b/ffi/primitives/primitives_library/primitives.c
@@ -27,9 +27,16 @@ int sum(int a, int b)
 
 int *multiply(int a, int b)
 {
+    // Allocates native memory in C.
     int *mult = (int *)malloc(sizeof(int));
     *mult = a * b;
     return mult;
+}
+
+void free_pointer(int *int_pointer)
+{
+    // Free native memory in C which was allocated in C.
+    free(int_pointer);
 }
 
 int subtract(int *a, int b)

--- a/ffi/structs/structs.dart
+++ b/ffi/structs/structs.dart
@@ -33,6 +33,10 @@ typedef reverse_native = Pointer<Utf8> Function(
     Pointer<Utf8> str, Int32 length);
 typedef Reverse = Pointer<Utf8> Function(Pointer<Utf8> str, int length);
 
+// C function: void free_string(char *str)
+typedef free_string_native = Void Function(Pointer<Utf8> str);
+typedef FreeString = void Function(Pointer<Utf8> str);
+
 // C function: struct Coordinate create_coordinate(double latitude, double longitude)
 typedef create_coordinate_native = Coordinate Function(
     Double latitude, Double longitude);
@@ -64,9 +68,15 @@ main() {
 
   final reverse = dylib.lookupFunction<reverse_native, Reverse>('reverse');
   final backwards = 'backwards';
-  final reversedMessage =
-      reverse(backwards.toNativeUtf8(), backwards.length).toDartString();
+  final backwardsUtf8 = backwards.toNativeUtf8();
+  final reversedMessageUtf8 = reverse(backwardsUtf8, backwards.length);
+  final reversedMessage = reversedMessageUtf8.toDartString();
+  calloc.free(backwardsUtf8);
   print('$backwards reversed is $reversedMessage');
+
+  final freeString =
+      dylib.lookupFunction<free_string_native, FreeString>('free_string');
+  freeString(reversedMessageUtf8);
 
   final createCoordinate =
       dylib.lookupFunction<create_coordinate_native, CreateCoordinate>(
@@ -75,9 +85,11 @@ main() {
   print(
       'Coordinate is lat ${coordinate.latitude}, long ${coordinate.longitude}');
 
+  final myHomeUtf8 = 'My Home'.toNativeUtf8();
   final createPlace =
       dylib.lookupFunction<create_place_native, CreatePlace>('create_place');
-  final place = createPlace('My Home'.toNativeUtf8(), 42.0, 24.0);
+  final place = createPlace(myHomeUtf8, 42.0, 24.0);
+  calloc.free(myHomeUtf8);
   final name = place.name.toDartString();
   final coord = place.coordinate;
   print(

--- a/ffi/structs/structs_library/structs.c
+++ b/ffi/structs/structs_library/structs.c
@@ -28,6 +28,7 @@ char *hello_world()
 
 char *reverse(char *str, int length)
 {
+    // Allocates native memory in C.
     char *reversed_str = (char *)malloc((length + 1) * sizeof(char));
     for (int i = 0; i < length; i++)
     {
@@ -35,6 +36,12 @@ char *reverse(char *str, int length)
     }
     reversed_str[length] = '\0';
     return reversed_str;
+}
+
+void free_string(char *str)
+{
+    // Free native memory in C which was allocated in C.
+    free(str);
 }
 
 struct Coordinate create_coordinate(double latitude, double longitude)


### PR DESCRIPTION
Closes https://github.com/dart-lang/samples/issues/93.

Native memory allocated in Dart is freed in Dart (`.toNativeUtf8()` -> `calloc.free()`).

Native memory allocated in C is freed in C (`malloc` -> `free`).

This symmetry makes it such that we never end up calling `free` on something `malloc`ed from another definition of `malloc` than the one that is in the same native library as `free`.