### PR TITLE
Sample to demonstrate use of Opaque

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignoring pub generated files.
 **/package_config.json
+.idea/
+.ccls-cache/

--- a/ffi/.gitignore
+++ b/ffi/.gitignore
@@ -1,7 +1,10 @@
 *.o
+*~
 *.dylib
 a.out
 .vscode/
+.idea/
+.ccls-cache/
 .packages
 sdk-version
 *snapshot*

--- a/ffi/opaque/.dockerignore
+++ b/ffi/opaque/.dockerignore
@@ -1,0 +1,1 @@
+hello_library/CMakeCache.txt

--- a/ffi/opaque/.dockerignore
+++ b/ffi/opaque/.dockerignore
@@ -1,1 +1,1 @@
-hello_library/CMakeCache.txt
+opaque_library/CMakeCache.txt

--- a/ffi/opaque/Dockerfile
+++ b/ffi/opaque/Dockerfile
@@ -1,0 +1,12 @@
+FROM google/dart:2.7
+
+WORKDIR /app
+
+ADD pubspec.* /app/
+RUN pub get
+COPY . /app
+RUN pub get --offline
+
+RUN apt-get update && apt-get install -y make gcc cmake
+
+CMD pub run test

--- a/ffi/opaque/README.md
+++ b/ffi/opaque/README.md
@@ -1,0 +1,30 @@
+# Opaque example
+
+This sample demonstrates use of Opaque types between C and Dart.
+
+While ffi has good support for dealing with common Struct/struct between code in the two languages, sometimes Dart code
+will call C code that returns an Opaque handle.  Even in C, programs don't generally examine these Opaque kinds of
+things.  Examples might be HWND in Windows programming, a MongoDB connection, a MySQL connection, and so on.  Basically
+handles to a "thing" where the handle struct is only really used by the underlying library, not the Dart or C code
+proper.
+
+For this example, we choose to implement a subset of ncurses (https://invisible-island.net/ncurses/announce.html) so
+these methods can be called from Dart.
+
+The gist of ncurses programming is that you call initscr(), then call various methods to clear the screen, move the
+cursor, render colors and attributes and so on.  The updates to the screen do not happen until you call refresh() or
+w=rewrefresh() - this is from the olden days where sending characters over a slow modem to update the screen was slow.
+
+We implemnnted a dynamic (or shared) library in C that exposes a handful of the ncurses methods to Dart.  Enough methods
+to clear the screen, print strings, read characters in raw mode (no echo, no buffering).  
+
+The initscr() method returns a WINDOW* in C, which we treat as an Opaque type in Dart.  The WINDOW* is returned from our
+ncurses_initscr() function.  Since the Dart code has no reason to care about the elements in the WINDOW* struct
+returned, we just declare it as type Window (extends Opaque).
+
+The test program exercises the few functions we exposse and reads keys in a loop until you hit the 'q' key.
+
+It should be noted that libncurses.so exists on Linux when ncurses is installed.  In theory, you can open that DynamicLibrary directly and call
+every method in ncurses that way.  However, using our own library allows us to conditionally compile for various
+operating systems, using the preprecessor ifdef/endif directives.
+

--- a/ffi/opaque/mono_pkg.yaml
+++ b/ffi/opaque/mono_pkg.yaml
@@ -1,0 +1,20 @@
+dart:
+  - dev
+  - stable
+
+os:
+  - linux
+  - macos
+  - windows
+
+stages:
+  - analyze:
+    - dartanalyzer: --fatal-infos .
+      os: linux
+    - dartfmt:
+      os: linux
+      dart: dev
+  - unit_test:
+    - test:
+      os:
+        - linux

--- a/ffi/opaque/opaque.dart
+++ b/ffi/opaque/opaque.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi'; //  as ffi;
+import 'dart:io' show Platform, Directory;
+import 'package:path/path.dart' as path;
+import 'package:ffi/ffi.dart';
+
+class Window extends Opaque {}
+
+// typedefs for the Dart ncurses_* functions and
+// FFI signatures of ncurses_* functions in our opaque_library.
+typedef native_initscr = Pointer<Window> Function();
+typedef dart_initscr = Pointer<Window> Function();
+
+typedef native_endwin = Void Function();
+typedef dart_endwin = void Function();
+
+typedef native_wmove = Void Function(Pointer<Window> window, Int64 row, Int64 col);
+typedef dart_wmove = void Function(Pointer<Window> window, int row, int col);
+
+typedef native_wclear = Void Function(Pointer<Window> window);
+typedef dart_wclear = void Function(Pointer<Window> window);
+
+typedef native_wrefresh = Void Function(Pointer<Window> window);
+typedef dart_wrefresh = void Function(Pointer<Window> window);
+
+typedef native_wgetch = Int64 Function(Pointer<Window> window);
+typedef dart_wgetch = int Function(Pointer<Window> window);
+
+typedef native_wprintw = Void Function(Pointer<Window> window, Pointer<Utf8> s);
+typedef dart_wprintw = void Function(Pointer<Window> window, Pointer<Utf8> s);
+
+typedef native_cbreak = Void Function();
+typedef dart_cbreak = void Function();
+typedef native_noecho = Void Function();
+typedef dart_noecho = void Function();
+
+main() {
+  // Open the dynamic library
+  var libraryPath =
+      path.join(Directory.current.path, 'opaque_library', 'libopaque.so');
+  if (Platform.isMacOS)
+    libraryPath =
+        path.join(Directory.current.path, 'opaque_library', 'libopaque.dylib');
+  if (Platform.isWindows)
+    libraryPath = path.join(
+        Directory.current.path, 'opaque_library', 'Debug', 'opaque.dll');
+
+  final DynamicLibrary dylib = DynamicLibrary.open(libraryPath);
+
+  // Look up the C functions.
+  final initscr =
+      dylib.lookupFunction<native_initscr, dart_initscr>('ncurses_initscr');
+  final endwin =
+      dylib.lookupFunction<native_endwin, dart_endwin>('ncurses_endwin');
+  final wclear =
+      dylib.lookupFunction<native_wclear, dart_wclear>('ncurses_wclear');
+  final wmove =
+      dylib.lookupFunction<native_wmove, dart_wmove>('ncurses_wmove');
+  final wrefresh =
+      dylib.lookupFunction<native_wrefresh, dart_wrefresh>('ncurses_wrefresh');
+  final wgetch =
+      dylib.lookupFunction<native_wgetch, dart_wgetch>('ncurses_wgetch');
+  final wprintw =
+      dylib.lookupFunction<native_wprintw, dart_wprintw>('ncurses_wprintw');
+  final cbreak =
+      dylib.lookupFunction<native_cbreak, dart_cbreak>('ncurses_cbreak');
+  final noecho =
+      dylib.lookupFunction<native_noecho, dart_noecho>('ncurses_noecho');
+
+  final win = initscr();
+  noecho();
+  cbreak();
+  wclear(win);
+  wprintw(win, 'hello, world\n'.toNativeUtf8());
+  wmove(win, 10, 10);
+  wprintw(win, 'at 10,10\n'.toNativeUtf8());
+  wmove(win, 20, 20);
+  wprintw(win, 'at 20,20 - HIT q TO QUIT\n'.toNativeUtf8());
+  wrefresh(win);
+
+  for (;;) {
+    final c = String.fromCharCode(wgetch(win));
+    if (c == 'q') {
+      break;
+    }
+    wprintw(win, 'char $c\n'.toNativeUtf8());
+    wrefresh(win);
+  }
+
+  endwin();
+}

--- a/ffi/opaque/opaque_library/.gitignore
+++ b/ffi/opaque/opaque_library/.gitignore
@@ -1,0 +1,21 @@
+# CMake generated files and directories
+CMakeCache.txt
+CMakeFiles/
+CmakeScripts/
+Makefile
+cmake_install.cmake
+
+# Xcode tooling generated via `cmake -G Xcode .`
+hello_library.xcodeproj/
+
+# Xcode generated build and output directories
+hello_library.build/
+
+# Generated test binary
+hello_test
+
+# Generated shared library files
+*.dylib
+*.so
+*.so.*
+*.dll

--- a/ffi/opaque/opaque_library/.gitignore
+++ b/ffi/opaque/opaque_library/.gitignore
@@ -6,13 +6,13 @@ Makefile
 cmake_install.cmake
 
 # Xcode tooling generated via `cmake -G Xcode .`
-hello_library.xcodeproj/
+opaque_library.xcodeproj/
 
 # Xcode generated build and output directories
-hello_library.build/
+opaque_library.build/
 
 # Generated test binary
-hello_test
+opaque_test
 
 # Generated shared library files
 *.dylib

--- a/ffi/opaque/opaque_library/CMakeLists.txt
+++ b/ffi/opaque/opaque_library/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+project(opaque_library VERSION 1.0.0 LANGUAGES C)
+add_library(opaque_library SHARED opaque.c opaque.def)
+find_package(Curses REQUIRED)
+
+target_link_libraries(opaque_library ${CURSES_LIBRARY})
+set_target_properties(opaque_library PROPERTIES
+    PUBLIC_HEADER opaque.h
+    VERSION ${PROJECT_VERSION}
+    SOVERSION 1
+    OUTPUT_NAME "opaque"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "Hex_Identity_ID_Goes_Here"
+)

--- a/ffi/opaque/opaque_library/opaque.c
+++ b/ffi/opaque/opaque_library/opaque.c
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <stdio.h>
+#include "opaque.h"
+
+int main() {
+  printf("main called\n");
+  return 0;
+}
+
+// Note:
+// ---only on Windows---
+// Every function needs to be exported to be able to access the functions by dart.
+// Refer: https://stackoverflow.com/q/225432/8608146
+
+Opaque ncurses_initscr() {
+  return (Opaque)initscr();
+}
+
+void ncurses_cbreak() {
+  cbreak();
+}
+
+void ncurses_noecho() {
+  noecho();
+}
+
+void ncurses_wprintw(WINDOW *window, char *s) {
+  wprintw(window, s);
+}
+
+void ncurses_wclear(WINDOW* window) {
+  wclear(window);
+}
+
+void ncurses_wrefresh(WINDOW* window) {
+  wrefresh(window);
+}
+
+int ncurses_wgetch(WINDOW* window) {
+  return wgetch(window);
+}
+
+void ncurses_wmove(WINDOW* window, int row, int col) {
+  wmove(window, row, col);
+}
+
+void ncurses_endwin() {
+  endwin();
+}

--- a/ffi/opaque/opaque_library/opaque.def
+++ b/ffi/opaque/opaque_library/opaque.def
@@ -1,0 +1,12 @@
+LIBRARY   opaque
+EXPORTS
+   ncurses_initscr
+   ncurses_cbreak
+   ncurses_noecho
+   ncurses_wclear
+   ncurses_wprintw
+   ncurses_wrefresh
+   ncurses_wgetch
+   ncurses_wmove
+   ncurses_endwin
+   

--- a/ffi/opaque/opaque_library/opaque.h
+++ b/ffi/opaque/opaque_library/opaque.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <ncurses.h>
+
+void opaque();
+
+typedef void *Opaque;
+
+Opaque ncurses_initscr();
+void ncurses_cbreak();
+void ncurses_noecho();
+
+void ncurses_wclear(WINDOW *window);
+void ncurses_wprintw(WINDOW *window, char *s);
+void ncurses_wrefresh(WINDOW *window);
+int ncurses_wgetch(WINDOW *window);
+
+void ncurses_wmove(WINDOW *window, int row, int col);
+
+void ncurses_endwin();

--- a/ffi/opaque/pubspec.yaml
+++ b/ffi/opaque/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hello_world_ffi
+version: 0.0.1
+description: >-
+  A super simple example of calling C code from Dart with FFI
+
+# This example isn't intended for publishing on pub.dev.
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  path: ^1.7.0
+  ffi: ^1.0.0
+
+dev_dependencies:
+  test: ^1.16.0
+  test_utils:
+    path: ../test_utils

--- a/ffi/opaque/pubspec.yaml
+++ b/ffi/opaque/pubspec.yaml
@@ -1,7 +1,7 @@
-name: hello_world_ffi
+name: opaque_ffi
 version: 0.0.1
 description: >-
-  A super simple example of calling C code from Dart with FFI
+  A super simple example of using Opaque handles between C and Dart
 
 # This example isn't intended for publishing on pub.dev.
 publish_to: none

--- a/ffi/opaque/test/opaque_test.dart
+++ b/ffi/opaque/test/opaque_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_utils/test_utils.dart';
+
+// These tests are Linux-only. For platform-specific instructions, see the
+// README.
+void main() async {
+  group('hello_world', () {
+    test('make dylib + execute', () async {
+      // run 'cmake .'
+      var cmake =
+          await Process.run('cmake', ['.'], workingDirectory: 'hello_library');
+      expect(cmake.exitCode, 0);
+
+      // run 'make'
+      var make =
+          await Process.run('make', [], workingDirectory: 'hello_library');
+      expect(make.exitCode, 0);
+
+      // Verify dynamic library was created (Linux only)
+      var filePath = getLibraryFilePath('hello_library', 'hello');
+      var file = File(filePath);
+      expect(await file.exists(), true, reason: '$filePath does not exist');
+
+      // Run the Dart script
+      var dartProcess = await Process.run('dart', ['hello.dart']);
+
+      // Verify program output
+      expect(dartProcess.stderr, isEmpty);
+      expect(dartProcess.stdout, equals('Hello World\n'));
+      expect(dartProcess.exitCode, equals(0));
+    });
+  });
+}

--- a/ffi/opaque/test/opaque_test.dart
+++ b/ffi/opaque/test/opaque_test.dart
@@ -6,29 +6,29 @@ import 'package:test_utils/test_utils.dart';
 // These tests are Linux-only. For platform-specific instructions, see the
 // README.
 void main() async {
-  group('hello_world', () {
+ group('opaque_world', () {
     test('make dylib + execute', () async {
       // run 'cmake .'
       var cmake =
-          await Process.run('cmake', ['.'], workingDirectory: 'hello_library');
+          await Process.run('cmake', ['.'], workingDirectory: 'opaque_library');
       expect(cmake.exitCode, 0);
 
       // run 'make'
       var make =
-          await Process.run('make', [], workingDirectory: 'hello_library');
+          await Process.run('make', [], workingDirectory: 'opaque_library');
       expect(make.exitCode, 0);
 
       // Verify dynamic library was created (Linux only)
-      var filePath = getLibraryFilePath('hello_library', 'hello');
+      var filePath = getLibraryFilePath('opaque_library', 'opaque');
       var file = File(filePath);
       expect(await file.exists(), true, reason: '$filePath does not exist');
 
       // Run the Dart script
-      var dartProcess = await Process.run('dart', ['hello.dart']);
+      var dartProcess = await Process.run('dart', ['opaque.dart']);
 
       // Verify program output
       expect(dartProcess.stderr, isEmpty);
-      expect(dartProcess.stdout, equals('Hello World\n'));
+      expect(dartProcess.stdout, equals('main called\n'));
       expect(dartProcess.exitCode, equals(0));
     });
   });


### PR DESCRIPTION
I looked around for a suitable library to use to demonstrate Opaque and came up with ncurses.  There are console libraries for Dart already, but none for ncurses that I saw - maybe it doesn't matter.  I initially wanted to do something like MySQL or MongoDB, but there are already native Dart packages for those.  Plus the setup and testing would require a MySQL or MongoDB server.

The idea here is that with ncurses, the initscr() function returns a WINDOW* that you can use with the w*(WINDOW *w, ...) methods.  There's a default global WINDOW* if you only have one (or maybe it's the first one) that allows you to call the non w*() versions of the routines.  For the purposes of our sample, we create class Window extends Opaque and get the Opaque handle from the exposed initscr() method in the dynamic library.  Then we pass that around to the ncurses methods that are exposed in the DLL.

In C, we can examine the elements of the WINDOW struct (if it even is a struct), but I've never done it in any ncurses programs I've developed over the years.  It really is an opaque kind of handle thingy.  

I did not bother to expose all of ncurses in the sample DLL, just enough to see that it works as expected and does something sorta useful.

In my Linux environment, there is a ncurses.so, so it might be that one could just open that and find the methods instead of having our intermediate DLL.

I added a README.md to the directory.  

This is the output of the demo program:

![image](https://user-images.githubusercontent.com/329637/119894198-26a9f380-bef1-11eb-8642-ef0ebff40155.png)


