### PR TITLE
Various minor clarifications around FFI samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Ignoring pub generated files.
 **/package_config.json
+
+# Ignore system and IDE files
+.idea
+.DS_STORE

--- a/ffi/.gitignore
+++ b/ffi/.gitignore
@@ -3,6 +3,7 @@
 a.out
 .vscode/
 .packages
+.dart_tool
 sdk-version
 *snapshot*
 pubspec.lock

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -2,7 +2,7 @@
 
 A series of simple examples demonstrating how to call C libraries from Dart.
 
-This code is designed to work with *Dart version 2.6.0* and above.
+This code is designed to work with *Dart version 2.12.0* and above.
 
 To learn more about FFI, start with the [C interop using
 dart:ffi](https://dart.dev/guides/libraries/c-interop) guide on dart.dev.
@@ -27,7 +27,7 @@ Once the native library is built, run:
 
 ```bash
 dart pub get
-dart <filename>.dart
+dart run <filename>.dart
 ```
 
 ## Using Docker
@@ -40,6 +40,7 @@ docker run dart-ffi
 ```
 
 ## macOS code signing
+
 The Dart binary can only load shared libraries that are *signed*. For more
 information, see [dart-lang/sdk/issues/38314][signing-issue] for details.
 

--- a/ffi/hello_world/pubspec.yaml
+++ b/ffi/hello_world/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  path: ^1.7.0
+  path: ^1.8.0
 
 dev_dependencies:
   lints: ^1.0.0

--- a/ffi/hello_world/pubspec.yaml
+++ b/ffi/hello_world/pubspec.yaml
@@ -15,5 +15,8 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
+  # test_utils depends on code elsewhere in the samples repository.
+  # You can reference it for useful cross-platform testing functionality
+  # or remove it if you want to use this example standalone.
   test_utils:
     path: ../test_utils

--- a/ffi/hello_world/test/hello_world_test.dart
+++ b/ffi/hello_world/test/hello_world_test.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:test_utils/test_utils.dart';
 
-// These tests are Linux-only. For platform-specific instructions, see the
-// README.
 void main() async {
   group('hello_world', () {
     test('make dylib + execute', () async {
@@ -18,7 +16,6 @@ void main() async {
           await Process.run('make', [], workingDirectory: 'hello_library');
       expect(make.exitCode, 0);
 
-      // Verify dynamic library was created (Linux only)
       var filePath = getLibraryFilePath('hello_library', 'hello');
       var file = File(filePath);
       expect(await file.exists(), true, reason: '$filePath does not exist');

--- a/ffi/primitives/pubspec.yaml
+++ b/ffi/primitives/pubspec.yaml
@@ -14,5 +14,8 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
+  # test_utils depends on code elsewhere in the samples repository.
+  # You can reference it for useful cross-platform testing functionality
+  # or remove it if you want to use this example standalone.
   test_utils:
     path: ../test_utils

--- a/ffi/primitives/test/primitives_test.dart
+++ b/ffi/primitives/test/primitives_test.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:test_utils/test_utils.dart';
 
-// These tests are Linux-only. For platform-specific instructions, see the
-// README.
 void main() async {
   group('primitives', () {
     test('make dylib + execute', () async {

--- a/ffi/structs/pubspec.yaml
+++ b/ffi/structs/pubspec.yaml
@@ -15,5 +15,8 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
+  # test_utils depends on code elsewhere in the samples repository.
+  # You can reference it for useful cross-platform testing functionality
+  # or remove it if you want to use this example standalone.
   test_utils:
     path: ../test_utils

--- a/ffi/structs/test/structs_test.dart
+++ b/ffi/structs/test/structs_test.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:test_utils/test_utils.dart';
 
-// These tests are Linux-only. For platform-specific instructions, see the
-// README.
 void main() async {
   group('structs', () {
     test('make dylib + execute', () async {


### PR DESCRIPTION
- Removes mention of tests only working on linux as they seem to work elsewhere after https://github.com/dart-lang/samples/commit/f0027c9092bfa3e2a1f2e658f5f92e179904ca45
- Mentions that these samples require Dart 2.12 as they were all updated to support null safety
- Updates `path` dependency to `^1.8.0` as that was the stable null safety release
- Adds an explanation when including `test_utils` as a dev dependency. As some people see these as templates and that is the only piece that requires other parts of the `samples` repository, potentially causing confusion when it doesn't work. (https://github.com/dart-lang/site-www/issues/3894)