### PR TITLE
Update -> Remove unnecessary const declaration

### DIFF
--- a/isolates/bin/send_and_receive.dart
+++ b/isolates/bin/send_and_receive.dart
@@ -12,7 +12,6 @@ import 'dart:isolate';
 const filename = 'json_01.json';
 
 Future<void> main() async {
-  final filename = 'json_01.json';
   final jsonData = await _spawnAndReceive(filename);
   print('Received JSON with ${jsonData.length} keys');
 }


### PR DESCRIPTION
filename constant is declared at the beginning so I guess we do not have to redeclared it in main()