### PR TITLE
Update `master` branch references to `main`

### DIFF
--- a/.github/workflows/package_constraint_solver.yaml
+++ b/.github/workflows/package_constraint_solver.yaml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ file you don't have to update the year.
 // BSD-style license that can be found in the LICENSE file.
 ```
 
-[dart-contributing]: https://github.com/dart-lang/sdk/blob/master/CONTRIBUTING.md
+[dart-contributing]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
 [issues]: https://github.com/dart-lang/samples/issues
 [pull-requests]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request
 [community]: https://dart.dev/community

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dart samples
 
-[![CI](https://github.com/dart-lang/samples/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/samples/actions?query=branch%3Amaster)
+[![CI](https://github.com/dart-lang/samples/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/samples/actions?query=branch%3Amain)
 
 A collection of [Dart][dart] programs that illustrate features and best
 practices. For a list of community-maintained projects, see [Awesome
@@ -8,26 +8,26 @@ Dart][awesome-dart].
 
 ## Index
 
-- [command_line](https://github.com/dart-lang/samples/blob/master/command_line) -
+- [command_line](https://github.com/dart-lang/samples/tree/main/command_line) -
   A command line app that parses command-line options and fetches from GitHub.
-- [extension_methods](https://github.com/dart-lang/samples/blob/master/extension_methods) -
+- [extension_methods](https://github.com/dart-lang/samples/tree/main/extension_methods) -
   A set of samples that demonstrates the extension methods syntax and shows some
   common use cases of the feature.
-- [null_safety/calculate_lix](https://github.com/dart-lang/samples/tree/master/null_safety/calculate_lix) -
+- [null_safety/calculate_lix](https://github.com/dart-lang/samples/tree/main/null_safety/calculate_lix) -
   A sample app that calculates the 'lix' readability index with an
   implementation that uses the tech preview of Dart's new null safety feature.
-- [ffi](https://github.com/dart-lang/samples/blob/master/ffi) - A series of
+- [ffi](https://github.com/dart-lang/samples/tree/main/ffi) - A series of
   simple examples demonstrating how to call C libraries from Dart.
-- [isolates](https://github.com/dart-lang/samples/blob/master/isolates) - Command line
+- [isolates](https://github.com/dart-lang/samples/tree/main/isolates) - Command line
   applications that demonstrate how to work with Concurrency in Dart using isolates.
   The examples read and parse JSON content in a worker isolate, and return the result to
   the main isolate.
-- [native_app](https://github.com/dart-lang/samples/blob/master/native_app) - A
+- [native_app](https://github.com/dart-lang/samples/tree/main/native_app) - A
   command line application that can be compiled to native code using
   `dart2native`.
-- [server](https://github.com/dart-lang/samples/blob/master/server) - Examples
+- [server](https://github.com/dart-lang/samples/tree/main/server) - Examples
   of running Dart on the server.
-- [package_constraint_solver](https://github.com/dart-lang/samples/blob/master/package_constraint_solver) - Demonstrates best-practices for publishing packages on pub.dev.
+- [package_constraint_solver](https://github.com/dart-lang/samples/tree/main/package_constraint_solver) - Demonstrates best-practices for publishing packages on pub.dev.
 
 ## More samples
 


### PR DESCRIPTION
This repository and the SDK now use `main` instead of `master`.