### PR TITLE
Remove `.packages` from gitignore files

### DIFF
--- a/command_line/.gitignore
+++ b/command_line/.gitignore
@@ -1,5 +1,4 @@
 .dart_tool/
-.packages
 pubspec.lock
 build/
 doc/api/

--- a/enhanced_enums/.gitignore
+++ b/enhanced_enums/.gitignore
@@ -1,5 +1,4 @@
 .dart_tool/
-.packages
 pubspec.lock
 build/
 doc/api/

--- a/extension_methods/.gitignore
+++ b/extension_methods/.gitignore
@@ -1,5 +1,4 @@
 .dart_tool/
-.packages
 pubspec.lock
 build/
 doc/api/

--- a/ffi/.gitignore
+++ b/ffi/.gitignore
@@ -2,7 +2,6 @@
 *.dylib
 a.out
 .vscode/
-.packages
 .dart_tool
 sdk-version
 *snapshot*

--- a/isolates/.gitignore
+++ b/isolates/.gitignore
@@ -1,4 +1,3 @@
 .dart_tool/
-.packages
 build/
 pubspec.lock

--- a/native_app/.gitignore
+++ b/native_app/.gitignore
@@ -1,5 +1,4 @@
 .dart_tool/
-.packages
 pubspec.lock
 build/
 doc/api/

--- a/null_safety/calculate_lix/.gitignore
+++ b/null_safety/calculate_lix/.gitignore
@@ -2,7 +2,6 @@ pubspec.lock
 
 # Files and directories used by the Dart SDK
 .dart_tool/
-.packages
 build/
 doc/api/
 

--- a/parameters/.gitignore
+++ b/parameters/.gitignore
@@ -1,6 +1,5 @@
 # Files and directories created by pub.
 .dart_tool/
-.packages
 
 # Conventional directory for build output.
 build/

--- a/server/google_apis/.gitignore
+++ b/server/google_apis/.gitignore
@@ -1,4 +1,4 @@
 # https://dart.dev/guides/libraries/private-files
 .dart_tool/
-.packages
+build/
 pubspec.lock

--- a/server/simple/.gitignore
+++ b/server/simple/.gitignore
@@ -1,4 +1,3 @@
 # https://dart.dev/guides/libraries/private-files
 .dart_tool/
-.packages
 pubspec.lock


### PR DESCRIPTION
This file has not been produced by pub for a while, it's no longer necessary to include it.