### PR TITLE
fix: fix typo for path on Windows

### DIFF
--- a/ffi/primitives/primitives.dart
+++ b/ffi/primitives/primitives.dart
@@ -52,7 +52,7 @@ void main() {
       Directory.current.path,
       'primitives_library',
       'Debug',
-      'primtives.dll',
+      'primitives.dll',
     );
   }
 


### PR DESCRIPTION
In the `ffi` sample, fix a typo that prevents the running of the `primitives` example on Windows. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
