### PR TITLE
docs: remove outdated null safety tech preview mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dart][awesome-dart].
   common use cases of the feature.
 - [null_safety/calculate_lix](https://github.com/dart-lang/samples/tree/main/null_safety/calculate_lix) -
   A sample app that calculates the 'lix' readability index with an
-  implementation that uses the tech preview of Dart's new null safety feature.
+  implementation that uses the Dart null safety feature.
 - [ffi](https://github.com/dart-lang/samples/tree/main/ffi) - A series of
   simple examples demonstrating how to call C libraries from Dart.
 - [isolates](https://github.com/dart-lang/samples/tree/main/isolates) - Command line


### PR DESCRIPTION
- Removed an outdated reference to the "tech preview" and "new" status of null safety in the root README.md.
- Updated the documentation to accurately reflect that null safety is now a standard, stable feature in Dart.
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
