### PR TITLE
Fix redeploy docs

### DIFF
--- a/server/simple/README.md
+++ b/server/simple/README.md
@@ -26,9 +26,19 @@ To deploy on [Cloud Run](https://cloud.google.com/run), click
 or follow
 [these instructions](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/other).
 
+#### Update deployment
+
+To redeploy your changes to Cloud Run, run the following command from this directory:
+
+```bash
+gcloud run deploy --source .
+```
+
+This command will build a container image using the local `Dockerfile` and update your service.
+
 ### With OS-only runtime
 
-Use [`tool/deploy_source.sh`](tool/deploy_source.sh) to build and 
+Use [`tool/deploy_source.sh`](tool/deploy_source.sh) to build and
 deploy using the
 [OS-only runtimes](https://docs.cloud.google.com/docs/buildpacks/osonly)
 feature.


### PR DESCRIPTION
PR adds clear instructions on how to redeploy the simple server to Google Cloud Run after making changes (like adding new assets to the `public/` directory). 

**Changes:**
- Updated [samples/server/simple/README.md](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/dart-sample/samples/server/simple/README.md:0:0-0:0) with a new "Update deployment" section.
- Added the command `gcloud run deploy --source .` which is the recommended way to rebuild and update the service when a [Dockerfile](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/dart-sample/samples/server/simple/Dockerfile:0:0-0:0) is present.

**Fixes:** 
- Fixes #232

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>